### PR TITLE
preparing for v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Add Airbrakex as a dependency to your `mix.exs` file:
 
 ```elixir
 defp deps do
-  [{:airbrakex, "~> 0.1.9"}]
+  [{:airbrakex, git: "https://github.com/rum-and-code/airbrakex.git", tag: "0.2.0"}]
 end
 ```
 
@@ -57,7 +57,7 @@ config :airbrakex,
 try do
   IO.inspect("test",[],"")
 rescue
-  exception -> Airbrakex.notify(exception)
+  exception -> Airbrakex.notify(exception, __STACKTRACE__)
 end
 ```
 
@@ -127,12 +127,3 @@ config :airbrakex,
   end
 ```
 
-
-## Thankx
- - [Airbrake Elixir](https://github.com/romul/airbrake-elixir)
- - [AirbrakePlug](https://github.com/romul/airbrake_plug)
- - [Rollbax](https://github.com/elixir-addicts/rollbax)
-
-## Thank you!
-
-[![Become Patreon](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/bePatron?u=6912974)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Add Airbrakex as a dependency to your `mix.exs` file:
 
 ```elixir
 defp deps do
-  [{:airbrakex, git: "https://github.com/rum-and-code/airbrakex.git", tag: "0.2.0"}]
+  [{:airbrakex, git: "https://github.com/rum-and-code/airbrakex.git", tag: "v0.2.0"}]
 end
 ```
 

--- a/lib/airbrakex.ex
+++ b/lib/airbrakex.ex
@@ -25,7 +25,7 @@ defmodule Airbrakex do
   try do
     IO.inspect("test",[],"")
   rescue
-    exception -> Airbrakex.notify(exception)
+    exception -> Airbrakex.notify(exception, __STACKTRACE__)
   end
   ```
 
@@ -56,6 +56,7 @@ defmodule Airbrakex do
   ## Parameters
 
     - exception: Exception to notify
+    - stacktrace: the __STACKTRACE__ from the catch/rescue block
     - options: Options
 
   ## Options
@@ -67,9 +68,9 @@ defmodule Airbrakex do
     - params
     - environment
   """
-  def notify(exception, options \\ []) do
+  def notify(exception, stacktrace \\ [], options \\ []) do
     exception
-    |> ExceptionParser.parse()
+    |> ExceptionParser.parse(stacktrace)
     |> Notifier.notify(options)
   end
 end

--- a/lib/airbrakex/exception_parser.ex
+++ b/lib/airbrakex/exception_parser.ex
@@ -1,7 +1,7 @@
 defmodule Airbrakex.ExceptionParser do
   @moduledoc false
 
-  def parse(exception, stacktrace) do
+  def parse(exception, stacktrace \\ []) do
     %{
       type: exception.__struct__,
       message: Exception.message(exception),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Airbrakex.Mixfile do
   def project do
     [
       app: :airbrakex,
-      version: "0.1.9",
+      version: "0.2.0",
       elixir: "~> 1.0",
       description: "Airbrake Elixir Notifier",
       package: package(),
@@ -12,16 +12,16 @@ defmodule Airbrakex.Mixfile do
       dialyzer: dialyzer(),
       docs: [
         main: Airbrakex,
-        source_url: "https://github.com/fazibear/airbrakex"
+        source_url: "https://github.com/rum-and-code/airbrakex"
       ]
     ]
   end
 
   def package() do
     [
-      maintainers: ["Michał Kalbarczyk"],
+      maintainers: ["Michał Kalbarczyk", "Rum&Code"],
       licenses: ["MIT"],
-      links: %{github: "https://github.com/fazibear/airbrakex"}
+      links: %{github: "https://github.com/rum-and-code/airbrakex"}
     ]
   end
 


### PR DESCRIPTION
- Taking ownership of our version of the repo
- Preparing for a  v0.2.0 release
- Add the `stacktrace` argument to `Airbrakex.notify` (breaking change)